### PR TITLE
Fix header parallax overflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,4 +41,37 @@ document.addEventListener("DOMContentLoaded", () => {
           }, 1000);
       });
   });
-});
+
+  const headerBk = document.querySelector('.header-bk');
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if (headerBk && !prefersReducedMotion.matches) {
+      let ticking = false;
+
+      const updateParallax = () => {
+          const offset = window.scrollY;
+          headerBk.style.backgroundPosition = `center 0px, center ${offset * -0.3}px`;
+          ticking = false;
+      };
+
+      const handleScroll = () => {
+          if (!ticking) {
+              window.requestAnimationFrame(updateParallax);
+              ticking = true;
+          }
+      };
+
+      updateParallax();
+      window.addEventListener('scroll', handleScroll);
+
+      prefersReducedMotion.addEventListener('change', (event) => {
+          if (event.matches) {
+              headerBk.style.removeProperty('background-position');
+              window.removeEventListener('scroll', handleScroll);
+          } else {
+              updateParallax();
+              window.addEventListener('scroll', handleScroll);
+          }
+      });
+  }
+  });

--- a/navbar.css
+++ b/navbar.css
@@ -11,9 +11,10 @@
         rgba(29,30,35,0.8)
     ),
     url(images/backg.jpg);
-    background-position: top center;
+    background-position: center 0, center 0;
     background-repeat: no-repeat;
     background-size: cover;
+    background-attachment: fixed;
     display: flex;
     align-items: center;
     min-height: 80vh;


### PR DESCRIPTION
## Summary
- enable fixed background on `.header-bk`
- animate background position on scroll for a parallax effect
- keep the gradient layer anchored while parallaxing to prevent white gaps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_684704f403688322b58cee7327a61411